### PR TITLE
Change grubup to use grub-mkconfig

### DIFF
--- a/config.fish
+++ b/config.fish
@@ -97,7 +97,7 @@ alias l.="exa -a | egrep '^\.'"                                     # show only 
 [ ! -x /usr/bin/yay ] && [ -x /usr/bin/paru ] && alias yay='paru'
 
 # Common use
-alias grubup="sudo update-grub"
+alias grubup="sudo grub-mkconfig -o /boot/grub/grub.cfg"
 alias fixpacman="sudo rm /var/lib/pacman/db.lck"
 alias tarnow='tar -acf '
 alias untar='tar -zxvf '


### PR DESCRIPTION
update-grub is missing at the moment and is just a hook that calls a command under the hood
see: https://aur.archlinux.org/cgit/aur.git/commit/?h=update-grub&id=3c7cd33fbea6a9af6056f6afb88101f1112bb754