### PR TITLE
cachyos-config: Use wayland backend on Electron 28+ applications

### DIFF
--- a/cachyos-config.fish
+++ b/cachyos-config.fish
@@ -28,6 +28,7 @@ if [ "$XDG_SESSION_TYPE" = "wayland" ]
     set -gx CLUTTER_BACKEND wayland
     set -gx ECORE_EVAS_ENGINE wayland_egl
     set -gx ELM_ENGINE wayland_egl
+    set -gx ELECTRON_OZONE_PLATFORM_HINT wayland
 end
 
 ## Environment setup


### PR DESCRIPTION
Adds the `ELECTRON_OZONE_PLATFORM_HINT` environment variable so Electron 28+ apps can use wayland instead of x11 via xwayland.

This mainly fixes Firefox opening as an xwayland app when clicking on Discord links when there is no open Firefox window.