### PR TITLE
history: Pass shell arguments to the custom function

### DIFF
--- a/cachyos-config.fish
+++ b/cachyos-config.fish
@@ -68,7 +68,7 @@ end
 
 # Fish command history
 function history
-    builtin history --show-time='%F %T '
+    builtin history --show-time='%F %T ' $argv
 end
 
 function backup --argument filename


### PR DESCRIPTION
Currently there is no way to pass additional arguments to this custom function, so for example `history -R` won't do anything. Make it accept arguments to correc this behaviour.

Fixes #18 
Closes #20 