### PR TITLE
cleanup: add user paths the fishy way

### DIFF
--- a/cachyos-config.fish
+++ b/cachyos-config.fish
@@ -1,7 +1,6 @@
 ﻿## Source from conf.d before our fish config
 source /usr/share/cachyos-fish-config/conf.d/done.fish
 
-
 ## Set values
 ## Run fastfetch as welcome message
 function fish_greeting
@@ -22,20 +21,8 @@ if test -f ~/.fish_profile
   source ~/.fish_profile
 end
 
-# Add ~/.local/bin to PATH
-if test -d ~/.local/bin
-    if not contains -- ~/.local/bin $PATH
-        set -p PATH ~/.local/bin
-    end
-end
-
-# Add depot_tools to PATH
-if test -d ~/Applications/depot_tools
-    if not contains -- ~/Applications/depot_tools $PATH
-        set -p PATH ~/Applications/depot_tools
-    end
-end
-
+# Append common directories for executable files to $PATH
+fish_add_path ~/.local/bin ~/.cargo/bin ~/Applications/depot_tools
 
 ## Functions
 # Functions needed for !! and !$ https://github.com/oh-my-fish/plugin-bang-bang


### PR DESCRIPTION
This pr switches to using fish_add_path. According to the fish documentation it happens to also check if the directories exist before adding them to path. This potentially could fix some issues as well since the previous method doesn't appear to have added the paths to the $fish_user_paths variable.