### PR TITLE
test-require-arg feature compatibility

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -225,7 +225,7 @@ if set -q __done_enabled
         # backwards compatibility for fish < v3.0
         set -q cmd_duration; or set -l cmd_duration $CMD_DURATION
 
-        if test $cmd_duration
+        if test -n $cmd_duration
             and test $cmd_duration -gt $__done_min_cmd_duration # longer than notify_duration
             and not __done_is_process_window_focused # process pane or window not focused
 


### PR DESCRIPTION
Make `done.fish` compatible with `test-require-arg` feature

> For historical reasons, test supports the one-argument form (test foo), and this will also be triggered by e.g. test -n $foo if $foo is unset. We recommend you don’t use the one-argument form and quote all variables or command substitutions used with test.
> This confusing misfeature will be removed in future. test -n without any additional argument will be false, test -z will be true and any other invocation with exactly one or zero arguments, including test -d and test "foo" will be an error.
> The same goes for [, e.g. [ "foo" ] and [ -d ] will be errors.
> This can be turned on already via the test-require-arg [feature flag](file:///usr/share/doc/fish/language.html#featureflags), and will eventually become the default and then only option.

— [Fish documentation](https://fishshell.com/docs/current/cmds/test.html)