### PR TITLE
Make `l.` alias look as nice as other `eza` aliases

### DIFF
--- a/cachyos-config.fish
+++ b/cachyos-config.fish
@@ -80,7 +80,7 @@ alias ls='eza -al --color=always --group-directories-first --icons=always' # pre
 alias la='eza -a --color=always --group-directories-first --icons=always'  # all files and dirs
 alias ll='eza -l --color=always --group-directories-first --icons=always'  # long format
 alias lt='eza -aT --color=always --group-directories-first --icons=always' # tree listing
-alias l.="eza -a --dereference | grep -e '^\.' | eza -ald --color=always --group-directories-first --icons=always" # show only dotfiles
+alias l.="eza -al --ignore-glob '[!.]*' --color=always --group-directories-first --icons=always" # show only dotfiles
 
 # Common use
 alias grubup="sudo grub-mkconfig -o /boot/grub/grub.cfg"

--- a/cachyos-config.fish
+++ b/cachyos-config.fish
@@ -80,7 +80,7 @@ alias ls='eza -al --color=always --group-directories-first --icons=always' # pre
 alias la='eza -a --color=always --group-directories-first --icons=always'  # all files and dirs
 alias ll='eza -l --color=always --group-directories-first --icons=always'  # long format
 alias lt='eza -aT --color=always --group-directories-first --icons=always' # tree listing
-alias l.="eza -a | grep -e '^\.'"                                     # show only dotfiles
+alias l.="eza -a --dereference | grep '^\.' | eza -ald --color=always --group-directories-first --icons=always" # show only dotfiles
 
 # Common use
 alias grubup="sudo grub-mkconfig -o /boot/grub/grub.cfg"

--- a/cachyos-config.fish
+++ b/cachyos-config.fish
@@ -80,7 +80,7 @@ alias ls='eza -al --color=always --group-directories-first --icons=always' # pre
 alias la='eza -a --color=always --group-directories-first --icons=always'  # all files and dirs
 alias ll='eza -l --color=always --group-directories-first --icons=always'  # long format
 alias lt='eza -aT --color=always --group-directories-first --icons=always' # tree listing
-alias l.="eza -a --dereference | grep '^\.' | eza -ald --color=always --group-directories-first --icons=always" # show only dotfiles
+alias l.="eza -a --dereference | grep -e '^\.' | eza -ald --color=always --group-directories-first --icons=always" # show only dotfiles
 
 # Common use
 alias grubup="sudo grub-mkconfig -o /boot/grub/grub.cfg"


### PR DESCRIPTION
Updates `l.` alias to pipe its output back into `eza` (with `-d` flag to not look into directories), so it will show filtered files and dirs in the same nice format with metadata as other `eza` aliases.

`--dereference` flag is needed so `eza` will not try to print where symlinks point to after `->` symbol, as this would break second `eza` call ([related `eza` issue](https://github.com/eza-community/eza/issues/1021)).